### PR TITLE
fixed exit function

### DIFF
--- a/Code/meteobike03.py
+++ b/Code/meteobike03.py
@@ -72,7 +72,9 @@ dht22_sensor = Adafruit_DHT.DHT22
 #callback functions
 def exit_program():
 	master.destroy()
-	sys.exit()
+	gpsp.running = False
+	gpsp.join()
+	sys.exit(0)
 def record_data():
 	global recording
 	recording=True


### PR DESCRIPTION
Fixed a problem where the exit was not done correctly. The `exit_program` function did not stop the thread for the gps so the thread kept running in the background and only the GUI was closed.